### PR TITLE
배틀 공격, 종료 기능 추가

### DIFF
--- a/app/src/main/java/com/example/softwareproject/ScreenCFragment.kt
+++ b/app/src/main/java/com/example/softwareproject/ScreenCFragment.kt
@@ -9,6 +9,10 @@ import dagger.hilt.android.AndroidEntryPoint
 import android.widget.Button
 import android.widget.EditText
 import android.widget.Toast
+import androidx.activity.viewModels
+import androidx.fragment.app.viewModels
+import com.example.softwareproject.com.example.softwareproject.presentation.fragmentc.ScreenCViewModel
+import com.example.softwareproject.com.example.softwareproject.presentation.room.viewmodel.PsBattleViewModel
 import com.example.softwareproject.util.UserPreferences
 
 @AndroidEntryPoint
@@ -17,6 +21,8 @@ class ScreenCFragment : Fragment() {
     private lateinit var editTextGithubId: EditText
     private lateinit var editTextSolvedAcHandle: EditText
     private lateinit var buttonSaveUserIds: Button
+
+    private val screencViewModel: ScreenCViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -61,7 +67,8 @@ class ScreenCFragment : Fragment() {
         context?.let {
             UserPreferences.saveGithubId(it, githubId)
             UserPreferences.saveSolvedAcHandle(it, solvedAcHandle)
-            Toast.makeText(it, "정보가 저장되었습니다.", Toast.LENGTH_SHORT).show()
         }
+        screencViewModel.saveBaekjoonInfo(solvedAcHandle)
+        Toast.makeText(context, "정보가 저장되었습니다.", Toast.LENGTH_SHORT).show()
     }
 }

--- a/app/src/main/java/com/example/softwareproject/data/dto/baekjoon/BaekjoonSolvedApiResponse.kt
+++ b/app/src/main/java/com/example/softwareproject/data/dto/baekjoon/BaekjoonSolvedApiResponse.kt
@@ -1,0 +1,10 @@
+package com.example.softwareproject.data.dto.baekjoon
+
+data class BaekjoonSolvedApiResponse(
+    val count: Int,
+    val items: List<ProblemItem>
+)
+
+data class ProblemItem(
+    val problemId: Int
+)

--- a/app/src/main/java/com/example/softwareproject/data/dto/room/ParticipantProblemState.kt
+++ b/app/src/main/java/com/example/softwareproject/data/dto/room/ParticipantProblemState.kt
@@ -1,4 +1,4 @@
-package com.example.softwareproject.com.example.softwareproject.data.dto.room
+package com.example.softwareproject.data.dto.room
 
 import com.google.firebase.Timestamp
 

--- a/app/src/main/java/com/example/softwareproject/data/dto/room/RoomParticipantDto.kt
+++ b/app/src/main/java/com/example/softwareproject/data/dto/room/RoomParticipantDto.kt
@@ -3,14 +3,16 @@ package com.example.softwareproject.data.dto.room
 import com.example.softwareproject.util.UserRole
 import com.google.firebase.Timestamp
 
+
 data class RoomParticipantDto(
     val userId: String = "",
     val attack: Int = 0,
     val hp: Int = 0,
+    val maxHp: Int = 100,
     val shield: Int = 0,
-    val role: UserRole = UserRole.GUEST, // 기본 역할 지정 (enum)
+    val role: UserRole = UserRole.GUEST,
     val roomId: String = "",
     val solvedProblem: Int = 0,
-    val createdAt: Timestamp? = null,     // Firestore Timestamp는 nullable 처리
-    val updatedAt: Timestamp? = null
+    val createdAt: Timestamp = Timestamp.now(),
+    val updatedAt: Timestamp = Timestamp.now()
 )

--- a/app/src/main/java/com/example/softwareproject/data/dto/user/BaekjoonInfoDto.kt
+++ b/app/src/main/java/com/example/softwareproject/data/dto/user/BaekjoonInfoDto.kt
@@ -1,0 +1,8 @@
+package com.example.softwareproject.com.example.softwareproject.data.dto.user
+
+data class BaekjoonInfoDto(
+    val userId: String = "",
+    val baekjoonId: String = "",
+    val count: Int = 0,
+    val items: List<String> = emptyList()
+)

--- a/app/src/main/java/com/example/softwareproject/data/repository/BattleRepositoryImpl.kt
+++ b/app/src/main/java/com/example/softwareproject/data/repository/BattleRepositoryImpl.kt
@@ -1,0 +1,46 @@
+package com.example.softwareproject.data.repository
+
+import com.example.softwareproject.domain.repository.BattleRepository
+import com.example.softwareproject.data.dto.room.RoomParticipantDto
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+
+class BattleRepositoryImpl @Inject constructor(
+    private val fireBaseStore : FirebaseFirestore
+) :BattleRepository {
+
+    override suspend fun updateParticipantHp(userId: String, roomId: String, newHp: Int) {
+        val doc = fireBaseStore.collection("room_participant")
+            .whereEqualTo("userId", userId)
+            .whereEqualTo("roomId", roomId)
+            .get()
+            .await()
+            .documents
+            .firstOrNull()
+
+        doc?.reference?.update("hp", newHp)?.await()
+    }
+
+    override fun observeRoomParticipants(roomId: String): Flow<List<RoomParticipantDto>> = callbackFlow {
+        val listener = fireBaseStore.collection("room_participant")
+            .whereEqualTo("roomId", roomId)
+            .addSnapshotListener { snapshot, error ->
+                if (error != null) {
+                    close(error)
+                    return@addSnapshotListener
+                }
+
+                val list = snapshot?.documents?.mapNotNull {
+                    it.toObject(RoomParticipantDto::class.java)
+                } ?: emptyList()
+
+                trySend(list).isSuccess // 안전 전송
+            }
+
+        awaitClose { listener.remove() }
+    }
+}

--- a/app/src/main/java/com/example/softwareproject/data/repository/ProblemRepositoryImpl.kt
+++ b/app/src/main/java/com/example/softwareproject/data/repository/ProblemRepositoryImpl.kt
@@ -5,7 +5,9 @@ import com.example.softwareproject.domain.repository.ProblemRepository
 import com.example.softwareproject.data.dto.problem.CsProblemDto
 import com.example.softwareproject.data.dto.problem.PsProblemDto
 import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class ProblemRepositoryImpl @Inject constructor(
@@ -127,6 +129,40 @@ class ProblemRepositoryImpl @Inject constructor(
         } catch (e: Exception) {
             Log.e("Repository", "문제 불러오기 실패: ${e.message}")
             PsProblemDto()
+        }
+    }
+
+    override suspend fun deleteCsProblem(csRoomId: String): Unit = withContext(NonCancellable) {
+        try {
+            val snapshot = fireBaseStore.collection("cs_problem")
+                .whereEqualTo("csRoomId", csRoomId)
+                .get()
+                .await()
+
+            for (doc in snapshot.documents) {
+                doc.reference.delete().await()
+            }
+
+            Log.d("Repository", "CS 문제 삭제 완료: $csRoomId")
+        } catch (e: Exception) {
+            Log.e("Repository", "CS 문제 삭제 실패: ${e.message}")
+        }
+    }
+
+    override suspend fun deletePsProblem(psRoomId: String): Unit = withContext(NonCancellable) {
+        try {
+            val snapshot = fireBaseStore.collection("coding_problem")
+                .whereEqualTo("codingRoomId", psRoomId)
+                .get()
+                .await()
+
+            for (doc in snapshot.documents) {
+                doc.reference.delete().await()
+            }
+
+            Log.d("Repository", "PS 문제 삭제 완료: $psRoomId")
+        } catch (e: Exception) {
+            Log.e("Repository", "PS 문제 삭제 실패: ${e.message}")
         }
     }
 

--- a/app/src/main/java/com/example/softwareproject/data/repository/RoomRepositoryImpl.kt
+++ b/app/src/main/java/com/example/softwareproject/data/repository/RoomRepositoryImpl.kt
@@ -1,17 +1,15 @@
 package com.example.softwareproject.data.repository
 
 import android.util.Log
-import com.example.softwareproject.com.example.softwareproject.data.dto.room.ParticipantProblemState
+import com.example.softwareproject.data.dto.room.ParticipantProblemState
 import com.example.softwareproject.data.dto.room.RoomDto
 import com.example.softwareproject.data.dto.room.RoomParticipantDto
 import com.example.softwareproject.data.dto.room.CsRoomDto
 import com.example.softwareproject.data.dto.room.PsRoomDto
-import com.example.softwareproject.data.nosql_entity.CodingProblem
 import com.example.softwareproject.data.remote.room.CsWaitingRoomInfo
 import com.example.softwareproject.data.remote.room.PsWaitingRoomInfo
 import com.example.softwareproject.domain.repository.RoomRepository
 import com.example.softwareproject.domain.repository.UserRepository
-import com.example.softwareproject.domain.repository.solvedac.RetrofitInstance
 import com.example.softwareproject.util.RoomState
 import com.example.softwareproject.util.RoomType
 import com.google.firebase.firestore.FirebaseFirestore

--- a/app/src/main/java/com/example/softwareproject/data/repository/RoomRepositoryImpl.kt
+++ b/app/src/main/java/com/example/softwareproject/data/repository/RoomRepositoryImpl.kt
@@ -288,6 +288,24 @@ class RoomRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun deleteParticipantProblemStatus(roomId: String): String? {
+        return try {
+            val snapshot = firebaseStore.collection("participant_problem_status")
+                .whereEqualTo("roomId", roomId)
+                .get()
+                .await()
+
+            for (doc in snapshot.documents) {
+                doc.reference.delete().await()
+            }
+
+            Log.d("Repository", "참가자 문제 상태 삭제 완료: $roomId")
+            roomId
+        } catch (e: Exception) {
+            Log.e("Repository", "참가자 문제 상태 삭제 실패: ${e.message}")
+            null
+        }
+    }
     override suspend fun roomStateChange(roomId: String, roomState: RoomState) {
         try {
             val snapshot = firebaseStore.collection("room")

--- a/app/src/main/java/com/example/softwareproject/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/example/softwareproject/data/repository/UserRepositoryImpl.kt
@@ -323,8 +323,12 @@ class UserRepositoryImpl @Inject constructor(
         }
     }
 
-
-
+    override suspend fun updateBaekjoonInfo(baekjoonInfoDto: BaekjoonInfoDto) {
+        fireBaseStore.collection("baekjoon_info")
+            .document(baekjoonInfoDto.userId)
+            .set(baekjoonInfoDto) // 덮어쓰기
+            .await()
+    }
 
 
 

--- a/app/src/main/java/com/example/softwareproject/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/example/softwareproject/data/repository/UserRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.example.softwareproject.data.repository
 
 import android.util.Log
+import com.example.softwareproject.com.example.softwareproject.data.dto.user.BaekjoonInfoDto
 import com.example.softwareproject.data.dto.user.GitHubInfoDto
 import com.example.softwareproject.data.dto.user.UserAbilityDto
 import com.example.softwareproject.data.dto.user.UserBattleLogDto
@@ -18,9 +19,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
+import com.example.softwareproject.com.example.softwareproject.module.BaekjoonApi as BaekjoonApi1
 
 class UserRepositoryImpl @Inject constructor(
-    private val fireBaseStore : FirebaseFirestore
+    private val fireBaseStore : FirebaseFirestore,
+    private val baekjoonApi: BaekjoonApi1
 ) : UserRepository{
 
     override suspend fun createUser(user: UserDto) {
@@ -66,7 +69,51 @@ class UserRepositoryImpl @Inject constructor(
             Log.e("Repository", "createUserGithubInfo failed: ${e.message}")
         }
     }
+    override suspend fun createUserBaekjoonInfo(baekjoonInfo: BaekjoonInfoDto){
+        try {
+            fireBaseStore.collection("baekjoon_info")
+                .document(baekjoonInfo.userId)
+                .set(baekjoonInfo)
+                .await()
+        } catch (e: Exception) {
+            Log.e("Repository", "createUserBaekjoonInfo failed: ${e.message}")
+        }
+    }
 
+    override suspend fun saveBaekjoonInfo(userId: String, solvedAcHandle: String) {
+        val allProblems = mutableListOf<String>()
+        var page = 1
+        var totalCount = 0
+
+        while (true) {
+            val response = baekjoonApi.getSolvedProblemByTag("s@$solvedAcHandle", page)
+
+            // 첫 페이지일 때 총 문제 수 저장
+            if (page == 1) {
+                totalCount = response.count
+            }
+
+            val currentProblems = response.items.map { it.problemId.toString() }
+            allProblems.addAll(currentProblems)
+
+            // 더 이상 읽을 게 없거나 전부 읽었으면 종료
+            if (currentProblems.isEmpty() || allProblems.size >= totalCount) break
+
+            page++
+        }
+
+        val dto = BaekjoonInfoDto(
+            userId = userId,
+            baekjoonId = solvedAcHandle,
+            count = totalCount,
+            items = allProblems
+        )
+
+        fireBaseStore.collection("baekjoon_info")
+            .document(userId)
+            .set(dto)
+            .await()
+    }
     override suspend fun getUserInfo(userId: String): UserDto? {
         return try {
             val snapshot = fireBaseStore.collection("user")
@@ -261,6 +308,21 @@ class UserRepositoryImpl @Inject constructor(
             )
         }
     }
+
+    override suspend fun getUserBaekjoonInfoByUserId(userId: String): BaekjoonInfoDto? {
+        return try {
+            val snapshot = fireBaseStore.collection("baekjoon_info")
+                .whereEqualTo("userId", userId)
+                .get()
+                .await()
+
+            snapshot.documents.firstOrNull()?.toObject(BaekjoonInfoDto::class.java)
+        } catch (e: Exception) {
+            Log.e("UserRepository", "Baekjoon 정보 불러오기 실패: ${e.message}")
+            null
+        }
+    }
+
 
 
 

--- a/app/src/main/java/com/example/softwareproject/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/example/softwareproject/data/repository/UserRepositoryImpl.kt
@@ -329,7 +329,53 @@ class UserRepositoryImpl @Inject constructor(
             .set(baekjoonInfoDto) // 덮어쓰기
             .await()
     }
+    override suspend fun updateBattleLogInfo(userBattleLogDto: UserBattleLogDto) {
+        try {
+            val snapshot = fireBaseStore.collection("user_battle_Log")
+                .whereEqualTo("userId", userBattleLogDto.userId)
+                .get()
+                .await()
 
+            val doc = snapshot.documents.firstOrNull()
+            if (doc != null) {
+                fireBaseStore.collection("user_battle_Log")
+                    .document(doc.id)
+                    .set(userBattleLogDto)
+                    .await()
+            } else {
+                // 문서가 없으면 새로 생성 (선택 사항)
+                fireBaseStore.collection("user_battle_Log")
+                    .add(userBattleLogDto)
+                    .await()
+            }
+        } catch (e: Exception) {
+            Log.e("UserRepository", "updateBattleLogInfo 실패: ${e.message}")
+        }
+    }
+
+    override suspend fun updateUserAbilityInfo(userAbility: UserAbilityDto) {
+        try {
+            val snapshot = fireBaseStore.collection("user_ability")
+                .whereEqualTo("userId", userAbility.userId)
+                .get()
+                .await()
+
+            val doc = snapshot.documents.firstOrNull()
+            if (doc != null) {
+                fireBaseStore.collection("user_ability")
+                    .document(doc.id)
+                    .set(userAbility)
+                    .await()
+            } else {
+                // 문서가 없으면 새로 생성 (선택 사항)
+                fireBaseStore.collection("user_ability")
+                    .add(userAbility)
+                    .await()
+            }
+        } catch (e: Exception) {
+            Log.e("UserRepository", "updateUserAbilityInfo 실패: ${e.message}")
+        }
+    }
 
 
 }

--- a/app/src/main/java/com/example/softwareproject/domain/repository/BattleRepository.kt
+++ b/app/src/main/java/com/example/softwareproject/domain/repository/BattleRepository.kt
@@ -1,0 +1,9 @@
+package com.example.softwareproject.domain.repository
+
+import com.example.softwareproject.data.dto.room.RoomParticipantDto
+import kotlinx.coroutines.flow.Flow
+
+interface BattleRepository {
+    suspend fun updateParticipantHp(userId: String, roomId: String, newHp: Int)
+    fun observeRoomParticipants(roomId: String): Flow<List<RoomParticipantDto>>
+}

--- a/app/src/main/java/com/example/softwareproject/domain/repository/ProblemRepository.kt
+++ b/app/src/main/java/com/example/softwareproject/domain/repository/ProblemRepository.kt
@@ -14,4 +14,7 @@ interface ProblemRepository {
     suspend fun getPsProblemList(psRoomId: String) : List<PsProblemDto>
     suspend fun getCsProblemByIndex(roomId: String, index: Int): CsProblemDto
     suspend fun getPsProblemByIndex(roomId: String, index: Int): PsProblemDto
+
+    suspend fun deleteCsProblem(csRoomId: String)
+    suspend fun deletePsProblem(psRoomId: String)
 }

--- a/app/src/main/java/com/example/softwareproject/domain/repository/RoomRepository.kt
+++ b/app/src/main/java/com/example/softwareproject/domain/repository/RoomRepository.kt
@@ -1,6 +1,6 @@
 package com.example.softwareproject.domain.repository
 
-import com.example.softwareproject.com.example.softwareproject.data.dto.room.ParticipantProblemState
+import com.example.softwareproject.data.dto.room.ParticipantProblemState
 import com.example.softwareproject.data.dto.problem.CsProblemDto
 import com.example.softwareproject.data.dto.room.RoomDto
 import com.example.softwareproject.data.dto.room.RoomParticipantDto

--- a/app/src/main/java/com/example/softwareproject/domain/repository/RoomRepository.kt
+++ b/app/src/main/java/com/example/softwareproject/domain/repository/RoomRepository.kt
@@ -38,6 +38,7 @@ interface RoomRepository {
     suspend fun deleteCsRoom(roomId: String) : String?
     suspend fun deletePsRoom(roomId: String) : String?
     suspend fun deleteRoomParticipant(roomId: String) : String?
+    suspend fun deleteParticipantProblemStatus(roomId: String) : String?
 
 
     suspend fun roomStateChange(roomId: String, roomState: RoomState)

--- a/app/src/main/java/com/example/softwareproject/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/example/softwareproject/domain/repository/UserRepository.kt
@@ -27,4 +27,7 @@ interface UserRepository {
     suspend fun getUSerGithubInfo(userId: String) : GitHubInfoDto?
     suspend fun getUserGithubInfoByFirebaseUid(firebaseUid: String) : GitHubInfoDto?
     suspend fun getUserBaekjoonInfoByUserId(userId: String) : BaekjoonInfoDto?
+
+    suspend fun updateBaekjoonInfo(baekjoonInfoDto: BaekjoonInfoDto)
+
 }

--- a/app/src/main/java/com/example/softwareproject/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/example/softwareproject/domain/repository/UserRepository.kt
@@ -1,5 +1,6 @@
 package com.example.softwareproject.domain.repository
 
+import com.example.softwareproject.com.example.softwareproject.data.dto.user.BaekjoonInfoDto
 import com.example.softwareproject.data.dto.user.GitHubInfoDto
 import com.example.softwareproject.data.dto.user.UserAbilityDto
 import com.example.softwareproject.data.dto.user.UserBattleLogDto
@@ -17,11 +18,13 @@ interface UserRepository {
     suspend fun createUserAbility(userAbility: UserAbilityDto)
     suspend fun createUserBattleLog(userBattleLogDto: UserBattleLogDto)
     suspend fun createUserGithubInfo(githubInfo:GitHubInfoDto)
+    suspend fun createUserBaekjoonInfo(baekjoonInfo: BaekjoonInfoDto)
+    suspend fun saveBaekjoonInfo(userId: String, solvedAcHandle: String)
 
     suspend fun getUserInfo(userId: String) : UserDto?
     suspend fun getUserAbilityInfo(userId: String) : UserAbilityDto?
     suspend fun getUserBattleLogInfo(userId: String) : UserBattleLogDto?
     suspend fun getUSerGithubInfo(userId: String) : GitHubInfoDto?
     suspend fun getUserGithubInfoByFirebaseUid(firebaseUid: String) : GitHubInfoDto?
-
+    suspend fun getUserBaekjoonInfoByUserId(userId: String) : BaekjoonInfoDto?
 }

--- a/app/src/main/java/com/example/softwareproject/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/example/softwareproject/domain/repository/UserRepository.kt
@@ -29,5 +29,6 @@ interface UserRepository {
     suspend fun getUserBaekjoonInfoByUserId(userId: String) : BaekjoonInfoDto?
 
     suspend fun updateBaekjoonInfo(baekjoonInfoDto: BaekjoonInfoDto)
-
+    suspend fun updateBattleLogInfo(userBattleLogDto: UserBattleLogDto)
+    suspend fun updateUserAbilityInfo(userAbility: UserAbilityDto)
 }

--- a/app/src/main/java/com/example/softwareproject/domain/usecase/room/BattleUseCase.kt
+++ b/app/src/main/java/com/example/softwareproject/domain/usecase/room/BattleUseCase.kt
@@ -2,7 +2,8 @@ package com.example.softwareproject.com.example.softwareproject.domain.usecase.r
 
 import android.util.Log
 import com.example.softwareproject.BuildConfig
-import com.example.softwareproject.com.example.softwareproject.data.dto.room.ParticipantProblemState
+import com.example.softwareproject.data.dto.room.ParticipantProblemState
+import com.example.softwareproject.domain.repository.BattleRepository
 import com.example.softwareproject.com.example.softwareproject.module.BaekjoonApi
 import com.example.softwareproject.data.dto.problem.BaekjoonProblemDto
 import com.example.softwareproject.data.dto.problem.CsProblemDto
@@ -19,6 +20,7 @@ import com.example.softwareproject.util.RoomType
 import com.example.softwareproject.util.UserRole
 import com.google.firebase.Timestamp
 import com.google.firebase.auth.FirebaseAuth
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class BattleUseCase@Inject constructor(
@@ -26,6 +28,7 @@ class BattleUseCase@Inject constructor(
     private val userRepository: UserRepository,
     private val problemRepository: ProblemRepository,
     private val geminiApiService: GeminiApi,
+    private val battleRepository: BattleRepository,
     private val baekjoonApi: BaekjoonApi
 
 ) {
@@ -209,6 +212,7 @@ class BattleUseCase@Inject constructor(
                 userId = hostUserId,
                 attack = hostUserAbility.attack,
                 hp = hostUserAbility.hp,
+                maxHp = hostUserAbility.hp,
                 shield = hostUserAbility.shield,
                 role = UserRole.HOST,
                 roomId = roomId,
@@ -224,6 +228,7 @@ class BattleUseCase@Inject constructor(
                 userId = participantUser.userId,
                 attack = participantUserAbility.attack,
                 hp = participantUserAbility.hp,
+                maxHp = participantUserAbility.hp,
                 shield = participantUserAbility.shield,
                 role = UserRole.GUEST,
                 roomId = roomId,
@@ -297,5 +302,17 @@ class BattleUseCase@Inject constructor(
             null
         }
     }
+    suspend fun updateParticipantHp(userId :String, roomId: String, newHp:Int){
+        battleRepository.updateParticipantHp(
+            userId = userId,
+            roomId = roomId,
+            newHp = newHp
+            )
+    }
+
+    fun observeRoomParticipants(roomId: String): Flow<List<RoomParticipantDto>> {
+        return battleRepository.observeRoomParticipants(roomId)
+    }
+
 
 }

--- a/app/src/main/java/com/example/softwareproject/domain/usecase/room/BattleUseCase.kt
+++ b/app/src/main/java/com/example/softwareproject/domain/usecase/room/BattleUseCase.kt
@@ -70,8 +70,12 @@ class BattleUseCase@Inject constructor(
         }
     }
     private fun buildPrompt(count: Int, topic: String, level: String): String {
+        val randomizer = System.currentTimeMillis()
         return """
         $topic 분야의 $level 수준 컴퓨터공학 객관식 퀴즈를 총 $count 문제 생성해줘.
+
+        문제 유형은 정의형, 응용형, 사례형, 오류 찾기형, 출력 결과 예측형 등을 골고루 섞어서 구성해줘.
+        문제마다 내용이 겹치지 않도록 주의하고, 다양한 개념과 난이도를 포함시켜줘.
 
         형식은 아래와 같이:
         문제: ...
@@ -81,7 +85,9 @@ class BattleUseCase@Inject constructor(
         4. ...
         정답: (1~4 중 하나)
 
-        각 문제는 줄로 나누고, 문제 사이에는 '---' 기호 3개로 구분해줘.
+        각 문제는 줄바꿈으로 구분하고, 문제와 문제 사이에는 '---' 기호 3개로 나눠줘.
+
+        문제에 랜덤성을 부여하기 위한 시드값: $randomizer
     """.trimIndent()
     }
     private fun parseGeminiToCsProblemList(response: String, csRoomId: String): List<CsProblemDto> {

--- a/app/src/main/java/com/example/softwareproject/domain/usecase/room/ProblemUseCase.kt
+++ b/app/src/main/java/com/example/softwareproject/domain/usecase/room/ProblemUseCase.kt
@@ -22,5 +22,12 @@ class ProblemUseCase @Inject constructor(
     suspend fun getPsProblemByIndex(roomId: String, index: Int): PsProblemDto {
         return problemRepository.getPsProblemByIndex(roomId, index)
     }
-
+    suspend fun deleteCsProblem(roomId: String){
+        val csRoom = roomRepository.getCsRoomInfoByRoomId(roomId)
+        csRoom?.let { problemRepository.deleteCsProblem(it.csRoomId) }
+    }
+    suspend fun deletePsProblem(roomId: String){
+        val psRoom = roomRepository.getPsRoomInfoByRoomId(roomId)
+        psRoom?.let { problemRepository.deletePsProblem(it.codingRoomId) }
+    }
 }

--- a/app/src/main/java/com/example/softwareproject/domain/usecase/room/RoomUseCase.kt
+++ b/app/src/main/java/com/example/softwareproject/domain/usecase/room/RoomUseCase.kt
@@ -272,4 +272,17 @@ class RoomUseCase @Inject constructor(
     suspend fun getPsRoomInfo(roomId: String): PsRoomDto? {
         return roomRepository.getPsRoomInfoByRoomId(roomId)
     }
+
+    suspend fun deleteCsRoom(roomId: String){
+        roomRepository.deleteCsRoom(roomId)
+    }
+    suspend fun deletePsRoom(roomId: String){
+        roomRepository.deletePsRoom(roomId)
+    }
+    suspend fun deleteParticipantProblemStatus(roomId: String){
+        roomRepository.deleteParticipantProblemStatus(roomId)
+    }
+    suspend fun deleteRoomParticipant(roomId: String){
+        roomRepository.deleteRoomParticipant(roomId)
+    }
 }

--- a/app/src/main/java/com/example/softwareproject/domain/usecase/room/UserUseCase.kt
+++ b/app/src/main/java/com/example/softwareproject/domain/usecase/room/UserUseCase.kt
@@ -1,5 +1,7 @@
 package com.example.softwareproject.com.example.softwareproject.domain.usecase.room
 
+import com.example.softwareproject.com.example.softwareproject.data.dto.user.BaekjoonInfoDto
+import com.example.softwareproject.data.dto.user.GitHubInfoDto
 import com.example.softwareproject.data.dto.user.UserAbilityDto
 import com.example.softwareproject.domain.repository.ProblemRepository
 import com.example.softwareproject.domain.repository.RoomRepository
@@ -15,6 +17,10 @@ class UserUseCase@Inject constructor(
 
     suspend fun getUserAbility(userId : String) : UserAbilityDto? {
         return userRepository.getUserAbilityInfo(userId)
+    }
+    suspend fun getCurrentGitHubInfo() : GitHubInfoDto? {
+        val uid = FirebaseAuth.getInstance().uid.toString()
+        return userRepository.getUserGithubInfoByFirebaseUid(uid)
     }
     suspend fun getCurrentUserAbility() :UserAbilityDto? {
         val uid = FirebaseAuth.getInstance().uid.toString()
@@ -33,6 +39,24 @@ class UserUseCase@Inject constructor(
         val opponent = participantList.firstOrNull { it.userId != myUserId } ?: return null
 
         return userRepository.getUserAbilityInfo(opponent.userId)
+    }
+
+    suspend fun saveBaekjoonInfo(solvedAcHandle: String) {
+        val firebaseUid = FirebaseAuth.getInstance().uid ?: return
+
+        val githubInfo = userRepository.getUserGithubInfoByFirebaseUid(firebaseUid)
+            ?: return
+
+        val userId = githubInfo.userId
+
+        val existingInfo = userRepository.getUserBaekjoonInfoByUserId(userId)
+
+        if (existingInfo == null) {
+            userRepository.saveBaekjoonInfo(
+                userId = userId,
+                solvedAcHandle = solvedAcHandle
+            )
+        }
     }
 
 }

--- a/app/src/main/java/com/example/softwareproject/module/BaekjoonApi.kt
+++ b/app/src/main/java/com/example/softwareproject/module/BaekjoonApi.kt
@@ -1,6 +1,7 @@
 package com.example.softwareproject.com.example.softwareproject.module
 
 
+import com.example.softwareproject.data.dto.baekjoon.BaekjoonSolvedApiResponse
 import com.example.softwareproject.data.dto.problem.BaekjoonApiResponse
 import retrofit2.http.GET
 import retrofit2.http.Query
@@ -11,4 +12,10 @@ interface BaekjoonApi {
         @Query("query") query: String,
         @Query("page") page: Int
     ): BaekjoonApiResponse
+
+    @GET("v3/search/problem")
+    suspend fun getSolvedProblemByTag(
+        @Query("query") query: String,
+        @Query("page") page: Int
+    ): BaekjoonSolvedApiResponse
 }

--- a/app/src/main/java/com/example/softwareproject/module/BattleRepositoryModule.kt
+++ b/app/src/main/java/com/example/softwareproject/module/BattleRepositoryModule.kt
@@ -1,0 +1,21 @@
+package com.example.softwareproject.module
+
+import com.example.softwareproject.data.repository.BattleRepositoryImpl
+import com.example.softwareproject.domain.repository.BattleRepository
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class BattleRepositoryModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindBattleRepository(
+        impl: BattleRepositoryImpl
+    ): BattleRepository
+}

--- a/app/src/main/java/com/example/softwareproject/module/GeminiApiModule.kt
+++ b/app/src/main/java/com/example/softwareproject/module/GeminiApiModule.kt
@@ -5,8 +5,10 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
 @Module
@@ -18,8 +20,15 @@ object GeminiApiModule {
     @Provides
     @Singleton
     fun provideGeminiApi(): GeminiApi {
+        val client = OkHttpClient.Builder()
+            .connectTimeout(30, TimeUnit.SECONDS)  // 연결 타임아웃
+            .readTimeout(30, TimeUnit.SECONDS)     // 읽기 타임아웃
+            .writeTimeout(30, TimeUnit.SECONDS)    // 쓰기 타임아웃
+            .build()
+
         return Retrofit.Builder()
             .baseUrl(BASE_URL)
+            .client(client)  // 👉 이걸 붙여야 타임아웃이 적용됨
             .addConverterFactory(GsonConverterFactory.create())
             .build()
             .create(GeminiApi::class.java)

--- a/app/src/main/java/com/example/softwareproject/presentation/fragmentc/ScreenCViewModel.kt
+++ b/app/src/main/java/com/example/softwareproject/presentation/fragmentc/ScreenCViewModel.kt
@@ -1,0 +1,19 @@
+package com.example.softwareproject.com.example.softwareproject.presentation.fragmentc
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.softwareproject.com.example.softwareproject.domain.usecase.room.UserUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ScreenCViewModel @Inject constructor(
+    private val userUseCase: UserUseCase
+) : ViewModel(){
+    fun saveBaekjoonInfo(solvedAcHandle: String) {
+        viewModelScope.launch {
+            userUseCase.saveBaekjoonInfo(solvedAcHandle)
+        }
+    }
+}

--- a/app/src/main/java/com/example/softwareproject/presentation/room/CsBattleActivity.kt
+++ b/app/src/main/java/com/example/softwareproject/presentation/room/CsBattleActivity.kt
@@ -9,6 +9,7 @@ import android.widget.RadioButton
 import android.widget.TextView
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.softwareproject.R
@@ -16,6 +17,7 @@ import com.example.softwareproject.RadioSelectionAdapter
 import com.example.softwareproject.SelectableItem
 import com.example.softwareproject.presentation.room.viewmodel.CsBattleViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class CsBattleActivity : AppCompatActivity() {
@@ -95,7 +97,10 @@ class CsBattleActivity : AppCompatActivity() {
 
             val homeBtn: Button = findViewById(R.id.home_btn)
             homeBtn.setOnClickListener {
-                finish()
+                lifecycleScope.launch {
+                    csBattleViewModels.giveUp(roomId)
+                    finish()
+                }
             }
 
             // TODO: 상대방 대기, 상태 갱신 로직 여기에 추가 가능

--- a/app/src/main/java/com/example/softwareproject/presentation/room/CsBattleActivity.kt
+++ b/app/src/main/java/com/example/softwareproject/presentation/room/CsBattleActivity.kt
@@ -36,7 +36,7 @@ class CsBattleActivity : AppCompatActivity() {
         val roomId = intent.getStringExtra("roomId") ?: return
 
         csBattleViewModels.loadAbility(roomId)
-
+        csBattleViewModels.observeParticipants(roomId)
 
         val yourHpText = findViewById<TextView>(R.id.your_hp_text)
         val yourHpBar = findViewById<ProgressBar>(R.id.xp_progress_bar)
@@ -93,6 +93,18 @@ class CsBattleActivity : AppCompatActivity() {
                 ).forEachIndexed { i, btn ->
                     btn.text = options[i]
                 }
+                val radioButtons = listOf(
+                    findViewById<RadioButton>(R.id.radio_button_option1),
+                    findViewById<RadioButton>(R.id.radio_button_option2),
+                    findViewById<RadioButton>(R.id.radio_button_option3),
+                    findViewById<RadioButton>(R.id.radio_button_option4)
+                )
+
+                radioButtons.forEachIndexed { index, btn ->
+                    btn.setOnClickListener {
+                        csBattleViewModels.selectAnswer(index + 1) // 1~4번 보기 선택
+                    }
+                }
             }
 
             val homeBtn: Button = findViewById(R.id.home_btn)
@@ -100,6 +112,12 @@ class CsBattleActivity : AppCompatActivity() {
                 lifecycleScope.launch {
                     csBattleViewModels.giveUp(roomId)
                     finish()
+                }
+            }
+            val attackBtn: Button = findViewById(R.id.attack_btn)
+            attackBtn.setOnClickListener {
+                lifecycleScope.launch {
+                    csBattleViewModels.attackOpponent(roomId)
                 }
             }
 

--- a/app/src/main/java/com/example/softwareproject/presentation/room/CsBattleActivity.kt
+++ b/app/src/main/java/com/example/softwareproject/presentation/room/CsBattleActivity.kt
@@ -1,6 +1,7 @@
 package com.example.softwareproject.com.example.softwareproject.presentation.room // 실제 패키지 이름으로 변경
 
 import android.annotation.SuppressLint
+import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import android.widget.Button
@@ -14,6 +15,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.softwareproject.R
 import com.example.softwareproject.RadioSelectionAdapter
+import com.example.softwareproject.ResultActivity
 import com.example.softwareproject.SelectableItem
 import com.example.softwareproject.presentation.room.viewmodel.CsBattleViewModel
 import dagger.hilt.android.AndroidEntryPoint
@@ -66,6 +68,15 @@ class CsBattleActivity : AppCompatActivity() {
                 SelectableItem("id_${index + 1}", "문제 ${index + 1}")
             }
 
+            csBattleViewModels.battleResult.observe(this) { result ->
+                result?.let {
+                    val intent = Intent(this, ResultActivity::class.java).apply {
+                        putExtra("result", result) // "WIN" 또는 "LOSE"
+                    }
+                    startActivity(intent)
+                    finish()
+                }
+            }
             radioAdapter = RadioSelectionAdapter(itemList) { selectedItem ->
                 val selectedIndex = selectedItem.id.removePrefix("id_").toInt()
                 csBattleViewModels.loadProblem(roomId, selectedIndex)

--- a/app/src/main/java/com/example/softwareproject/presentation/room/PsBattleActivity.kt
+++ b/app/src/main/java/com/example/softwareproject/presentation/room/PsBattleActivity.kt
@@ -13,6 +13,7 @@ import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity // AppCompatActivity 상속
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.viewModelScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.softwareproject.R
@@ -42,7 +43,7 @@ class PsBattleActivity : AppCompatActivity() {
         val roomId = intent.getStringExtra("roomId") ?: return
 
         psBattleViewModel.loadAbility(roomId)
-
+        psBattleViewModel.observeParticipantHp(roomId)
 
         val yourHpText = findViewById<TextView>(R.id.your_hp_text)
         val yourHpBar = findViewById<ProgressBar>(R.id.xp_progress_bar)
@@ -95,13 +96,17 @@ class PsBattleActivity : AppCompatActivity() {
                     finish() // 그 다음 종료
                 }
             }
+            val attackBtn: Button = findViewById(R.id.attack_btn)
+            attackBtn.setOnClickListener {
+                lifecycleScope.launch {
+                    psBattleViewModel.attackOpponent(roomId)
+                }
+            }
 
-            // TODO: 상대방 대기, 상태 갱신 로직 여기에 추가 가능
         }
         // 사용자가 시스템의 뒤로가기 버튼을 눌렀을 때도 finish()와 동일하게 동작
     }
 
-    // 사용자가 시스템의 뒤로가기 버튼을 눌렀을 때도 finish()와 동일하게 동작
     override fun onBackPressed() {
         super.onBackPressed() // 기본 동작 (finish() 호출)
     }

--- a/app/src/main/java/com/example/softwareproject/presentation/room/PsBattleActivity.kt
+++ b/app/src/main/java/com/example/softwareproject/presentation/room/PsBattleActivity.kt
@@ -12,6 +12,7 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity // AppCompatActivity 상속
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.softwareproject.R
@@ -20,6 +21,7 @@ import com.example.softwareproject.SelectableItem
 import com.example.softwareproject.com.example.softwareproject.presentation.room.viewmodel.PsBattleViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -88,7 +90,10 @@ class PsBattleActivity : AppCompatActivity() {
 
             val homeBtn: Button = findViewById(R.id.home_btn)
             homeBtn.setOnClickListener {
-                finish()
+                lifecycleScope.launch {
+                    psBattleViewModel.giveUp(roomId)  // 비동기 작업 다 끝날 때까지 기다림
+                    finish() // 그 다음 종료
+                }
             }
 
             // TODO: 상대방 대기, 상태 갱신 로직 여기에 추가 가능

--- a/app/src/main/java/com/example/softwareproject/presentation/room/PsBattleActivity.kt
+++ b/app/src/main/java/com/example/softwareproject/presentation/room/PsBattleActivity.kt
@@ -18,6 +18,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.softwareproject.R
 import com.example.softwareproject.RadioSelectionAdapter
+import com.example.softwareproject.ResultActivity
 import com.example.softwareproject.SelectableItem
 import com.example.softwareproject.com.example.softwareproject.presentation.room.viewmodel.PsBattleViewModel
 import dagger.hilt.android.AndroidEntryPoint
@@ -71,6 +72,16 @@ class PsBattleActivity : AppCompatActivity() {
         psBattleViewModel.problemCount.observe(this) { count ->
             val itemList = List(count) { index ->
                 SelectableItem("id_${index + 1}", "문제 ${index + 1}")
+            }
+
+            psBattleViewModel.battleResult.observe(this) { result ->
+                result?.let {
+                    val intent = Intent(this, ResultActivity::class.java).apply {
+                        putExtra("result", result) // "WIN" 또는 "LOSE"
+                    }
+                    startActivity(intent)
+                    finish()
+                }
             }
 
             radioAdapter = RadioSelectionAdapter(itemList) { selectedItem ->

--- a/app/src/main/java/com/example/softwareproject/presentation/room/viewmodel/CsBattleViewModel.kt
+++ b/app/src/main/java/com/example/softwareproject/presentation/room/viewmodel/CsBattleViewModel.kt
@@ -12,7 +12,9 @@ import com.example.softwareproject.data.dto.problem.CsProblemDto
 import com.example.softwareproject.domain.usecase.room.ProblemUseCase
 import com.example.softwareproject.domain.usecase.room.RoomUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
@@ -94,6 +96,17 @@ class CsBattleViewModel @Inject constructor(
             _opponentMaxHp.value = opponentUser?.hp
 
             Log.d("TabCsFragment", "받은 방 개수: ${_yourHp.value} ${yourMaxHp.value} ${_opponentHp.value} ${_opponentMaxHp.value}")
+        }
+    }
+    fun giveUp(roomId: String) {
+        viewModelScope.launch {
+            withContext(NonCancellable) {
+            problemUseCase.deleteCsProblem(roomId)
+//            roomUseCase.deleteCsRoom(roomId)
+            roomUseCase.deleteRoomParticipant(roomId)
+            roomUseCase.deleteParticipantProblemStatus(roomId)
+//            roomUseCase.deleteRoom(roomId)
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/softwareproject/presentation/room/viewmodel/CsBattleViewModel.kt
+++ b/app/src/main/java/com/example/softwareproject/presentation/room/viewmodel/CsBattleViewModel.kt
@@ -9,10 +9,13 @@ import androidx.lifecycle.viewModelScope
 import com.example.softwareproject.com.example.softwareproject.domain.usecase.room.BattleUseCase
 import com.example.softwareproject.com.example.softwareproject.domain.usecase.room.UserUseCase
 import com.example.softwareproject.data.dto.problem.CsProblemDto
+import com.example.softwareproject.data.dto.room.RoomParticipantDto
 import com.example.softwareproject.domain.usecase.room.ProblemUseCase
 import com.example.softwareproject.domain.usecase.room.RoomUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -24,6 +27,9 @@ class CsBattleViewModel @Inject constructor(
     private val userUseCase: UserUseCase,
     private val roomUseCase: RoomUseCase
 ) : ViewModel() {
+
+    private val _selectedAnswerIndex = MutableLiveData<Int>() // 1~4
+    val selectedAnswerIndex: LiveData<Int> = _selectedAnswerIndex
 
     private val _problemCount = MutableLiveData<Int>()
     val problemCount: LiveData<Int> = _problemCount
@@ -98,6 +104,7 @@ class CsBattleViewModel @Inject constructor(
             Log.d("TabCsFragment", "받은 방 개수: ${_yourHp.value} ${yourMaxHp.value} ${_opponentHp.value} ${_opponentMaxHp.value}")
         }
     }
+
     fun giveUp(roomId: String) {
         viewModelScope.launch {
             withContext(NonCancellable) {
@@ -109,4 +116,48 @@ class CsBattleViewModel @Inject constructor(
             }
         }
     }
+    fun attackOpponent(roomId: String) {
+        viewModelScope.launch {
+
+            val selected = _selectedAnswerIndex.value
+            val problem = _currentProblem.value
+
+            if(selected == null || problem == null) return@launch
+
+            val isCorrect = selected == problem.correctChoice.toInt()
+
+            if (isCorrect) {
+
+                val opponent = battleUseCase.getOpponentRoomParticipant(roomId)
+                val newHp = (opponent?.hp ?: 0) - 1
+                battleUseCase.updateParticipantHp(opponent?.userId ?: return@launch, roomId, newHp.coerceAtLeast(0))
+            } else {
+                val me = battleUseCase.getCurrentRoomParticipant(roomId)
+                val newHp = (me?.hp ?: 0) - 1
+                battleUseCase.updateParticipantHp(me?.userId ?: return@launch, roomId, newHp.coerceAtLeast(0))
+            }
+        }
+    }
+
+    fun selectAnswer(index: Int) {
+        _selectedAnswerIndex.value = index
+    }
+
+    fun observeParticipants(roomId: String) {
+        viewModelScope.launch {
+            battleUseCase.observeRoomParticipants(roomId).collect { participants ->
+                val currentUserId = userUseCase.getCurrentUserAbility()?.userId
+                participants.forEach { participant ->
+                    if (participant.userId == currentUserId) {
+                        _yourHp.postValue(participant.hp)
+                        _yourMaxHp.postValue(participant.maxHp)
+                    } else {
+                        _opponentHp.postValue(participant.hp)
+                        _opponentMaxHp.postValue(participant.maxHp)
+                    }
+                }
+            }
+        }
+    }
+
 }

--- a/app/src/main/java/com/example/softwareproject/presentation/room/viewmodel/PsBattleViewModel.kt
+++ b/app/src/main/java/com/example/softwareproject/presentation/room/viewmodel/PsBattleViewModel.kt
@@ -26,6 +26,10 @@ class PsBattleViewModel @Inject constructor(
     private val roomUseCase: RoomUseCase
 ) : ViewModel()
 {
+
+    private val _battleResult = MutableLiveData<String?>()
+    val battleResult: LiveData<String?> = _battleResult
+
     private val _problemCount = MutableLiveData<Int>()
     val problemCount: LiveData<Int> = _problemCount
 
@@ -133,9 +137,18 @@ class PsBattleViewModel @Inject constructor(
             if (hasSolved) {
                 val newOpponentHp = (opponentUser.hp - 1).coerceAtLeast(0)
                 battleUseCase.updateParticipantHp(opponentUser.userId, roomId, newOpponentHp)
+                if(newOpponentHp == 0)
+                {
+                    battleUseCase.finishGame(roomId, winnerUserId = currentUser.userId, losserUserId = opponentUser.userId)
+                    _battleResult.value = "WIN"
+                }
             } else {
                 val newYourHp = (currentUser.hp - 1).coerceAtLeast(0)
                 battleUseCase.updateParticipantHp(currentUser.userId, roomId, newYourHp)
+                if(newYourHp == 0){
+                    battleUseCase.finishGame(roomId, winnerUserId = opponentUser.userId, losserUserId = currentUser.userId)
+                    _battleResult.value = "LOSE"
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/softwareproject/presentation/room/viewmodel/PsBattleViewModel.kt
+++ b/app/src/main/java/com/example/softwareproject/presentation/room/viewmodel/PsBattleViewModel.kt
@@ -13,7 +13,9 @@ import com.example.softwareproject.data.dto.problem.PsProblemDto
 import com.example.softwareproject.domain.usecase.room.ProblemUseCase
 import com.example.softwareproject.domain.usecase.room.RoomUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
@@ -95,6 +97,17 @@ class PsBattleViewModel @Inject constructor(
             _opponentMaxHp.value = opponentUser?.hp
 
             Log.d("TabCsFragment", "받은 방 개수: ${_yourHp.value} ${yourMaxHp.value} ${_opponentHp.value} ${_opponentMaxHp.value}")
+        }
+    }
+    fun giveUp(roomId: String) {
+        viewModelScope.launch {
+            withContext(NonCancellable) {
+                problemUseCase.deletePsProblem(roomId)
+                //roomUseCase.deletePsRoom(roomId)
+                roomUseCase.deleteRoomParticipant(roomId)
+                roomUseCase.deleteParticipantProblemStatus(roomId)
+//            roomUseCase.deleteRoom(roomId)
+            }
         }
     }
 }

--- a/app/src/main/res/layout/activity_battle_cs.xml
+++ b/app/src/main/res/layout/activity_battle_cs.xml
@@ -226,6 +226,7 @@
             android:layout_margin="8dp"/>
 
         <Button
+            android:id="@+id/attack_btn"
             android:layout_width="0dp"
             android:layout_weight="1"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_battle_ps.xml
+++ b/app/src/main/res/layout/activity_battle_ps.xml
@@ -222,6 +222,7 @@
             android:layout_margin="8dp"/>
 
         <Button
+            android:id="@+id/attack_btn"
             android:layout_width="0dp"
             android:layout_weight="1"
             android:layout_height="wrap_content"


### PR DESCRIPTION
# 이슈 사항
- 현재 백엔드 로직에서 거쳐가는 분기점이 너무 많아서 그런지 HP가 실시간으로 반영되는데 시간이 좀 걸리는거 같습니다. 다른 네트워크 환경에서는 더 개선되어서 돌아갈지 모르겠네요!!
- 백준 문제 로직은 한문제씩 비교하는게 없어서 List로 저장해놓고 하고 있는데 어쩔 수 없이 API로 호출해서 비교하는 로직이 필요합니다. 문제를 많이 푼 사람일수록 반환받는 값이 많기 때문에 더 오래 걸릴수도 있을 거 같아요!
- 차후에 로직은 좀 더 개선해보도록 하겠습니다 
- 현재 : ViewModel -> UseCase -> Repository 순으로 접근
- 여기서 API가 더 추가되기 때문에 느린 현상이 발생하는 거 같습니다.